### PR TITLE
Add a spellchecking demo that also shows use of native node module

### DIFF
--- a/spellchecking/README.md
+++ b/spellchecking/README.md
@@ -1,6 +1,6 @@
 # Spellchecking Demo
 
-This demo relies on the [spellchecker](https://github.com/atom/node-spellchecker) node module which maps through to the native spellchecker APIs on Mac, Windows, and Linux. Because this module runs native code, it needs to be compiled. It's important that you compile it for the version of Atom Shell you are using using the [instructions here](https://github.com/atom/electron/blob/master/docs/tutorial/using-native-node-modules.md).
+This demo uses the [spellchecker](https://github.com/atom/node-spellchecker) node module which maps through to native spelling APIs on Mac, Windows, and Linux. This module needs to be compiled since it runs native code, and it's important that you compile it for the version of Electron you are using. With `apm` installed you can run the commands below. See the [instructions here](https://github.com/atom/electron/blob/master/docs/tutorial/using-native-node-modules.md) for more information.
 
 ```
 export ATOM_NODE_VERSION=0.26.0

--- a/spellchecking/README.md
+++ b/spellchecking/README.md
@@ -1,0 +1,23 @@
+# Spellchecking Demo
+
+This demo relies on the [spellchecker](https://github.com/atom/node-spellchecker) node module which maps through to the native spellchecker APIs on Mac, Windows, and Linux. Because this module runs native code, it needs to be compiled. It's important that you compile it for the version of Atom Shell you are using using the [instructions here](https://github.com/atom/electron/blob/master/docs/tutorial/using-native-node-modules.md).
+
+```
+export ATOM_NODE_VERSION=0.26.0
+cd spellchecking
+apm install .
+```
+
+If you do this wrong, you'll see one of these two messages in the console:
+
+```
+[37332:0514/214811:INFO:CONSOLE(134)] "Uncaught Error: Module version mismatch. Expected 43, got 41.", source: ATOM_SHELL_ASAR.js (134)
+
+---> You compiled the module against the wrong version of Electron.
+```
+
+```
+[37617:0514/215117:INFO:CONSOLE(134)] "Uncaught Error: Module did not self-register.", source: ATOM_SHELL_ASAR.js (134)
+
+---> You compiled the module using `npm` not `apm`, or it otherwise couldn't be loaded into Electron.
+```

--- a/spellchecking/app.css
+++ b/spellchecking/app.css
@@ -1,0 +1,5 @@
+html, body, video {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+}

--- a/spellchecking/app.js
+++ b/spellchecking/app.js
@@ -1,0 +1,10 @@
+
+// initialize spell checking
+checker = require('spellchecker');
+require('web-frame').setSpellCheckProvider("en-US", true, {
+    spellCheck: function(text) {
+        console.log("Spellchecker called on "+text);
+        return !checker.isMisspelled(text);
+    }
+});
+

--- a/spellchecking/index.html
+++ b/spellchecking/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Spellchecker Test</title>
+    <link rel="stylesheet" href="app.css">
+    <script src="app.js"></script>
+  </head>
+  <body>
+    <div contenteditable="true" style="width:100%; height:100%; line-height:1.5em; font-size:1.2em; padding:20px;">
+        This is a contenteditable region. Type away!
+    </div>
+  </body>
+</html>

--- a/spellchecking/main.js
+++ b/spellchecking/main.js
@@ -1,0 +1,33 @@
+var app = require('app');  // Module to control application life.
+var BrowserWindow = require('browser-window');  // Module to create native browser window.
+
+// Report crashes to our server.
+require('crash-reporter').start();
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the javascript object is GCed.
+var mainWindow = null;
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function() {
+  if (process.platform != 'darwin')
+    app.quit();
+});
+
+// This method will be called when Electron has done everything
+// initialization and ready for creating browser windows.
+app.on('ready', function() {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 800, height: 600});
+
+  // and load the index.html of the app.
+  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function() {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null;
+  });
+});

--- a/spellchecking/package.json
+++ b/spellchecking/package.json
@@ -1,0 +1,8 @@
+{
+  "name"    : "spellchecker-demo",
+  "version" : "0.1.0",
+  "main"    : "main.js",
+  "dependencies": {
+      "spellchecker": "2.2.0"
+  }
+}


### PR DESCRIPTION
Here's a tiny app that shows how to use the spellchecking feature in Atom Shell. I think it might be a good demo, though there's not much to it. I put it together to reproduce a bug!