### PR TITLE
update loadUrl to loadURL in file-explorer example

### DIFF
--- a/file-explorer/main.js
+++ b/file-explorer/main.js
@@ -21,7 +21,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {

--- a/file-explorer/main.js
+++ b/file-explorer/main.js
@@ -2,7 +2,10 @@ var app = require('app');  // Module to control application life.
 var BrowserWindow = require('browser-window');  // Module to create native browser window.
 
 // Report crashes to our server.
-require('crash-reporter').start();
+require('crash-reporter').start({
+  companyName: 'YourCompany',
+  submitURL: 'https://your-domain.com/url-to-submit'
+});
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.

--- a/file-explorer/script.js
+++ b/file-explorer/script.js
@@ -28,7 +28,7 @@ var App = {
   about: function () {
     var params = {toolbar: false, resizable: false, show: true, height: 150, width: 400};
     aboutWindow = new BrowserWindow(params);
-    aboutWindow.loadUrl('file://' + __dirname + '/about.html');
+    aboutWindow.loadURL('file://' + __dirname + '/about.html');
   },
 
   // change folder for sidebar links


### PR DESCRIPTION
The latest Electron will prompt that loadUrl is deprecated. The new API is
loadURL. We also need to update other samples to use the API instead.