### PR TITLE
[DesktopCapture]"Disable Capture" button not working

### DIFF
--- a/desktop-capture/app.js
+++ b/desktop-capture/app.js
@@ -49,7 +49,7 @@ function toggle() {
     desktopSharing = false;
 
     if (localStream)
-      localStream.stop();
+      localStream.getTracks()[0].stop();
     localStream = null;
 
     document.querySelector('button').innerHTML = "Enable Capture";

--- a/desktop-capture/main.js
+++ b/desktop-capture/main.js
@@ -13,7 +13,7 @@ app.setPath("userData", __dirname + "/saved_recordings");
 app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
 
   mainWindow.on('closed', function() {
     mainWindow = null;


### PR DESCRIPTION
MediumStream.stop is deprecated