### PR TITLE
Fix for addSource()

### DIFF
--- a/desktop-capture/app.js
+++ b/desktop-capture/app.js
@@ -28,7 +28,7 @@ function addSource(source) {
     value: source.id.replace(":", ""),
     text: source.name
   }));
-  $('select option[value=' + source.id.replace(":", "") + ']').attr('data-img-src', source.thumbnail.toDataUrl());
+  $('select option[value="' + source.id.replace(":", "") + '"]').attr('data-img-src', source.thumbnail.toDataUrl());
   refresh();
 }
 


### PR DESCRIPTION
The css selector used to get the options by value were not quoted and therefore would break depending on the `source.id`.