### PR TITLE
enableRemoteModule set to true, which is by default false

### DIFF
--- a/file-explorer/main.js
+++ b/file-explorer/main.js
@@ -12,7 +12,7 @@ app.on('window-all-closed', function() {
 // initialization and ready for creating browser windows.
 app.on('ready', function() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600, webPreferences: {nodeIntegration: true}});
+  mainWindow = new BrowserWindow({width: 800, height: 600, webPreferences: {nodeIntegration: true, enableRemoteModule: true}});
 
   // and load the index.html of the app.
   mainWindow.loadURL('file://' + __dirname + '/index.html');

--- a/mini-code-editor/main.js
+++ b/mini-code-editor/main.js
@@ -12,7 +12,7 @@ app.on('window-all-closed', function() {
 // initialization and ready for creating browser windows.
 app.on('ready', function() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600, webPreferences: {nodeIntegration: true}});
+  mainWindow = new BrowserWindow({width: 800, height: 600, webPreferences: {nodeIntegration: true, enableRemoteModule: true}});
 
   // and load the index.html of the app.
   mainWindow.loadURL('file://' + __dirname + '/index.html');


### PR DESCRIPTION
In newer version of Electron (10.0.0 and above), webPreferences enableRemoteModule is false by default due to which File Manager and Mini Code Editor example weren't working.