### PR TITLE
Fix for require not defined on electron 12+

### DIFF
--- a/desktop-capture/main.js
+++ b/desktop-capture/main.js
@@ -10,7 +10,7 @@ app.on('window-all-closed', () => {
 app.setPath("userData", __dirname + "/saved_recordings");
 
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({width: 800, height: 600, webPreferences: {nodeIntegration: true}});
+  mainWindow = new BrowserWindow({width: 800, height: 600, webPreferences: {nodeIntegration: true, contextIsolation: false}});
 
   mainWindow.loadURL('file://' + __dirname + '/index.html');
 


### PR DESCRIPTION
Breaking changes in electron 12 [here:](https://www.electronjs.org/docs/breaking-changes#default-changed-contextisolation-defaults-to-true) 

require() cannot be used in the renderer process unless nodeIntegration is true and contextIsolation is false.